### PR TITLE
store secret keys as env variables

### DIFF
--- a/src/main/java/org/marketplace/configuration/DataLoader.java
+++ b/src/main/java/org/marketplace/configuration/DataLoader.java
@@ -3,10 +3,10 @@ package org.marketplace.configuration;
 import org.marketplace.models.User;
 import org.marketplace.repositories.UserManagementRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.lang.NonNull;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -18,13 +18,17 @@ public class DataLoader implements ApplicationListener<ApplicationReadyEvent> {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private Environment env;
+
     @Override
-    public void onApplicationEvent(ApplicationReadyEvent event) {
+    public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
         if (userRepository.count() == 0) {
             User user = new User();
-            user.setEmail("user1@test.com");
-            user.setPassword(passwordEncoder.encode("pass"));
-            user.setLogin("user1");
+            user.setEmail(env.getProperty("user.default.email"));
+            user.setPassword(passwordEncoder.encode(env.getProperty("user.default.password")));
+            user.setLogin(env.getProperty("user.default.login"));
             userRepository.save(user);
         }
     }

--- a/src/main/resources/application-secrets.properties
+++ b/src/main/resources/application-secrets.properties
@@ -1,0 +1,4 @@
+user.default.email=user1@test.com
+user.default.password=password
+user.default.login=user1
+secret=Z0qa(jhLvr|#OHNxK'0^(ehC:~=~]1l)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update
 server.port=8080
 spring.main.allow-circular-references=true
+spring.config.name=application,application-secrets


### PR DESCRIPTION
In some cases, we used plain text as a way to store our secret values (default email, default password, or secret key to jwt auth). 

Created `application-secrets.properties` file to store our secret values. 

I am aware that we are exposing those at this moment (and it is not a proper practice), but for learning purposes I am including those files for now so all of you can take a look at it and see how it works.

This PR is blocked by #24 - as the usage of `SECRET` is in BaseJWT that was removed. We need to substitute the field in `TokenService` that uses the secret with proper variable from env.