### PR TITLE
add JsonIgnore property to password field

### DIFF
--- a/src/main/java/org/marketplace/models/User.java
+++ b/src/main/java/org/marketplace/models/User.java
@@ -1,5 +1,6 @@
 package org.marketplace.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -17,6 +18,7 @@ public class User {
     @Size(min = 5, max = 20, message = "Login must be between 5 and 20 characters long")
     private String login;
     @NotNull
+    @JsonIgnore
     private String password;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
By adding `@JsonIgnore` property to password field we avoid exposing users hashed password for all response instances.

This resolves issue #32 [hashed passwords exposure]